### PR TITLE
Add 'Allowed OAuth Flows' to enable hosted UI

### DIFF
--- a/cloudformation/templates/spunt_auth.py
+++ b/cloudformation/templates/spunt_auth.py
@@ -64,6 +64,8 @@ spunt_be_client = template.add_resource(UserPoolClient(
     'SpuntCognitoClient',
     UserPoolId=Ref(user_pool),
     ClientName='spunt-users',
+    AllowedOAuthFlows=['token'],
+    AllowedOAuthScopes=['profile'],
     CallbackURLs=['https://spunt.be/login'],  # TODO: Store this somewhere
     LogoutURLs=['https://spunt.be/logout'],
     SupportedIdentityProviders=['COGNITO'],  # TODO: Add facebook and google


### PR DESCRIPTION
- Since we're hosting our app on S3, it means we have to use 'implicit grant'.
- Also added the ability to fetch the profile details of the user